### PR TITLE
Add features

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,4 @@
 [
 	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
-	{ "keys": ["ctrl+alt+c"], "command": "fold_current_comments"},
-	{ "keys": ["ctrl+alt+shift+c"], "command": "unfold_current_comments"},
+	{ "keys": ["ctrl+alt+c"], "command": "toggle_fold_current_comments"},
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,5 @@
 [
-	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" }
+	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
+	{ "keys": ["ctrl+alt+c"], "command": "fold_current_comments"},
+	{ "keys": ["ctrl+alt+shift+c"], "command": "unfold_current_comments"},
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,5 @@
 [
-	{ "keys": ["super+shift+c"], "command": "toggle_fold_comments" }
+	{ "keys": ["super+shift+c"], "command": "toggle_fold_comments" },
+	{ "keys": ["super+alt+c"], "command": "fold_current_comments"},
+	{ "keys": ["super+alt+shift+c"], "command": "unfold_current_comments"},
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,4 @@
 [
 	{ "keys": ["super+shift+c"], "command": "toggle_fold_comments" },
-	{ "keys": ["super+alt+c"], "command": "fold_current_comments"},
-	{ "keys": ["super+alt+shift+c"], "command": "unfold_current_comments"},
+	{ "keys": ["super+alt+c"], "command": "toggle_fold_current_comments"},
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,4 @@
 [
 	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
-	{ "keys": ["ctrl+alt+c"], "command": "fold_current_comments"},
-	{ "keys": ["ctrl+alt+shift+c"], "command": "unfold_current_comments"},
+	{ "keys": ["ctrl+alt+c"], "command": "toggle_fold_current_comments"},
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,5 @@
 [
-	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" }
+	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
+	{ "keys": ["ctrl+alt+c"], "command": "fold_current_comments"},
+	{ "keys": ["ctrl+alt+shift+c"], "command": "unfold_current_comments"},
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -19,4 +19,8 @@
         "caption": "Unfold Current Comments",
         "command": "unfold_current_comments"
     },
+    {
+        "caption": "Toggle Fold Current Comments",
+        "command": "toggle_fold_current_comments"
+    },
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -10,5 +10,13 @@
     {
         "caption": "Toggle Fold Comments",
         "command": "toggle_fold_comments"
-    }
+    },
+    {
+        "caption": "Fold Current Comments",
+        "command": "fold_current_comments"
+    },
+    {
+        "caption": "Unfold Current Comments",
+        "command": "unfold_current_comments"
+    },
 ]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ You can install via [Sublime Package Manager](https://sublime.wbond.net/) where 
 
 ###### OSX
 Toggle Comments Folding: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Fold Current Comments: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
+Unfold Current Comments: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
 
 ###### Windows/Linux
 Toggle Comments Folding: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Fold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
+Unfold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
 
 
 #### Commands
@@ -26,6 +30,8 @@ Toggle Comments Folding: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
 * `Toggle Folding Comments`
 * `Fold Comments`
 * `Unfold Comments`
+* `Fold Current Comments`
+* `Unfold Current Comments`
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -15,21 +15,20 @@ You can install via [Sublime Package Manager](https://sublime.wbond.net/) where 
 #### Keybinds
 
 ###### OSX
-Toggle Comments Folding: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
-Fold Current Comments: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
-Unfold Current Comments: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Toggle Fold Comments: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Toggle Fold Current Comments: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
 
 ###### Windows/Linux
-Toggle Comments Folding: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
-Fold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
-Unfold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Toggle Fold Comments: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Toggle Fold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
 
 
 #### Commands
 
-* `Toggle Folding Comments`
+* `Toggle Fold Comments`
 * `Fold Comments`
 * `Unfold Comments`
+* `Toggle Fold Current Comments`
 * `Fold Current Comments`
 * `Unfold Current Comments`
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Unfold Current Comments: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <
 * `Unfold Current Comments`
 
 
+#### Settings
+
+* `"fold_single_line_comments": true`  # Fold single line comments.
+* `"show_first_line": false`  # Show the first line of multiline comments.
+* `"autofold": false`  # Automatically fold comments when a file is loaded.
+
+
 ## Credits
 
 This plugin builds on the work of

--- a/foldcomments.py
+++ b/foldcomments.py
@@ -163,6 +163,21 @@ class CommentNodes:
 
         self.unfold() if is_folded(self.comments) else self.fold()
 
+    def current_comments(self):
+        new_sels = []
+        for s in reversed(self.view.sel()):
+            if s.empty():
+                for comment in self.comments:
+                    if comment.contains(s):
+                        new_sels.append(comment)
+        return new_sels
+
+    def fold_current(self):
+        self.view.fold(self.current_comments())
+
+    def unfold_current(self):
+        self.view.unfold(self.current_comments())
+
 
 # ================================= COMMANDS ==================================
 
@@ -185,6 +200,20 @@ class UnfoldCommentsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         comments = CommentNodes(self.view)
         comments.unfold()
+
+
+class FoldCurrentCommentsCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        comments = CommentNodes(self.view)
+        comments.fold_current()
+
+
+class UnfoldCurrentCommentsCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        comments = CommentNodes(self.view)
+        comments.unfold_current()
 
 
 class FoldFileComments(sublime_plugin.EventListener):

--- a/foldcomments.py
+++ b/foldcomments.py
@@ -142,6 +142,9 @@ class CommentNodes:
         if not self.settings.get('fold_single_line_comments'):
             comments = self.remove_single_line_comments(comments)
 
+        if self.settings.get('ignore_assigned'):
+            comments = self.remove_assigned(comments)
+
         if self.settings.get('show_first_line'):
             comments = self.show_first_line(comments)
 
@@ -175,6 +178,13 @@ class CommentNodes:
             concatenated_comments.append(concatenated_comment or comment)
 
         return concatenated_comments
+
+    def remove_assigned(self, comments):
+        regex = re.compile(r"[\s\w]*\=")
+        return [
+            c for c in comments if not regex.match(self.view.substr(
+                self.view.lines(c)[0]))
+        ]
 
     def show_first_line(self, comments):
         """Leave the first line visible for multi line comments.

--- a/foldcomments.py
+++ b/foldcomments.py
@@ -185,3 +185,11 @@ class UnfoldCommentsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         comments = CommentNodes(self.view)
         comments.unfold()
+
+
+class FoldFileComments(sublime_plugin.EventListener):
+
+    def on_load(self, view):
+        if load_settings("foldcomments.sublime-settings").get('autofold'):
+            comments = CommentNodes(view)
+            comments.fold()

--- a/foldcomments.py
+++ b/foldcomments.py
@@ -119,10 +119,16 @@ class CommentNodes:
         return comments
 
     def find_comments_raw(self):
-        return [
+        comments = [
             normalize_comment(self.view, c) for c in
             self.view.find_by_selector('comment')
         ]
+        if self.settings.get('fold_strings'):
+            comments += [
+                normalize_comment(self.view, c) for c in
+                self.view.find_by_selector('string')
+            ]
+        return comments
 
     def apply_settings(self, comments):
         """Settings to apply before any processing"""
@@ -177,7 +183,7 @@ class CommentNodes:
         to take up a line with (...) anyways.
         """
         # Regex of possible comment start characters.
-        regex = re.compile(r"[\s\'\"\\\ \(\)\{\}#/*%<>!-=]*")
+        regex = re.compile(r"\s*@?(doc)?[\s\'\"\\\ \(\)\{\}#/*%<>!-=]*")
         new_fold = []
         for c in comments:
             if is_comment_multi_line(self.view, c):

--- a/foldcomments.py
+++ b/foldcomments.py
@@ -214,12 +214,19 @@ class CommentNodes:
     def unfold_all(self):
         self.view.unfold(self.find_comments())
 
-    def toggle_folding(self):
-        def is_folded(comments):
-            return self.view.unfold(comments[0])  # False if /already folded/
+    def is_folded(self, comments):
+        return self.view.unfold(comments[0])  # False if /already folded/
 
+    def toggle_fold_all(self):
         comments = self.find_comments()
-        self.unfold_all() if is_folded(comments) else self.fold_all()
+        self.unfold_all() if self.is_folded(comments) else self.fold_all()
+
+    def toggle_fold_current(self):
+        comments = self.current_comments()
+        if self.is_folded(comments):
+            self.unfold_current()
+        else:
+            self.fold_current()
 
     def current_comments(self):
         comments = self.apply_settings(self.find_comments_raw())
@@ -242,7 +249,7 @@ class ToggleFoldCommentsCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         comments = CommentNodes(self.view)
-        comments.toggle_folding()
+        comments.toggle_fold_all()
 
 
 class FoldCommentsCommand(sublime_plugin.TextCommand):
@@ -257,6 +264,13 @@ class UnfoldCommentsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         comments = CommentNodes(self.view)
         comments.unfold_all()
+
+
+class ToggleFoldCurrentCommentsCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        comments = CommentNodes(self.view)
+        comments.toggle_fold_current()
 
 
 class FoldCurrentCommentsCommand(sublime_plugin.TextCommand):

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -15,6 +15,27 @@
 	// (..)
 	"concatenate_adjacent_comments": true,
 
+	// Should multiline comments be concatenated.
+	//
+	// If concatenate_adjacent_comments is true and
+	// concatenate_multiline_comments is true then
+	// all adjacent comments will be concatenated.
+	//
+	// If false then multiline comments will not be concatenated.
+	"concatenate_multiline_comments": false,
+
+	// Should we concatenate over empty lines.
+	//
+	// If true then comments with an empty line in between them are
+	// considered as adjacent.
+	//
+	// Example:
+	//
+	// # These 2 comments are adjacent when true.
+	//
+	// # These 2 comments are not adjacent when false.
+	"concatenate_over_empty_lines": true,
+
 	// Includes "inline" comments, like so:
 	//
 	// function foobar(baz) {

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -20,7 +20,7 @@
 	// function foobar(baz) {
 	// 	return baz * 2; // this is an inline comment <--
 	// }
-	"fold_single_line_comments": true,
+	"fold_single_line_comments": false,
 
 	// Keep the first line visible when folding multiline comments.
 	//
@@ -36,7 +36,7 @@
 	//
 	// Instead of:
 	// (...)
-	"show_first_line": false,
+	"show_first_line": true,
 
 	// Make show_first_line also show the closing comment characters.
 	//
@@ -59,7 +59,7 @@
 	// Also fold strings.
 	//
 	// Strings are often used as comments.
-	"fold_strings": false,
+	"fold_strings": true,
 
 	// Ignore assigned.
 	//

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -40,4 +40,9 @@
 
 	// Automatically fold comments when a file is loaded.
 	"autofold": false,
+
+	// Also fold strings.
+	//
+	// Strings are often used as comments.
+	"fold_strings": false
 }

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -20,5 +20,8 @@
 	// function foobar(baz) {
 	// 	return baz * 2; // this is an inline comment <--
 	// }
-	"fold_single_line_comments": true
+	"fold_single_line_comments": true,
+
+	// Automatically fold comments when a file is loaded.
+	"autofold": false,
 }

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -44,5 +44,16 @@
 	// Also fold strings.
 	//
 	// Strings are often used as comments.
-	"fold_strings": false
+	"fold_strings": false,
+
+	// Ignore assigned.
+	//
+	// Only want to fold strings that are comments.
+	// If a string is assigned to a variable ignore it.
+	//
+	// Example:
+	//
+	// Test = """Hello
+	//    World!"""
+	"ignore_assigned":false,
 }

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -22,6 +22,22 @@
 	// }
 	"fold_single_line_comments": true,
 
+	// Keep the first line visible when folding multiline comments.
+	//
+	// Example:
+	//
+	// # This is the first line.
+	// #
+	// # This is not the first line.
+	// # This is also not the first line.
+	//
+	// Would get turned into:
+	// # This is the first line. (...)
+	//
+	// Instead of:
+	// (...)
+	"show_first_line": false,
+
 	// Automatically fold comments when a file is loaded.
 	"autofold": false,
 }

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -38,6 +38,21 @@
 	// (...)
 	"show_first_line": false,
 
+	// Make show_first_line also show the closing comment characters.
+	//
+	// Example:
+	//
+	// /*
+	//  * Hello World!
+	//  */
+	//
+	// Would get turned into:
+	// /*(...)Hello World!(...)*/
+	//
+	// Instead of:
+	// /*(...)Hello World!(...)
+	"show_closing_comment_characters": true,
+
 	// Automatically fold comments when a file is loaded.
 	"autofold": false,
 

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -1,5 +1,5 @@
 {
-	// Adjacent single- and block comments
+	// Adjacent single line comments
 	// get turned into a single fold
 	//
 	// Example:

--- a/foldcomments.sublime-settings
+++ b/foldcomments.sublime-settings
@@ -53,9 +53,6 @@
 	// /*(...)Hello World!(...)
 	"show_closing_comment_characters": true,
 
-	// Automatically fold comments when a file is loaded.
-	"autofold": false,
-
 	// Also fold strings.
 	//
 	// Strings are often used as comments.
@@ -71,4 +68,16 @@
 	// Test = """Hello
 	//    World!"""
 	"ignore_assigned":false,
+
+	// Automatically fold comments when a file is loaded.
+	"autofold": false,
+
+	// If autofold is true then automatically fold the following syntaxes.
+	//
+	// If syntaxes is empty then fold every syntax.
+	// If syntaxes is not empty only fold the stynaxes in syntaxes.
+	//
+	// Example: You only want to autofold python code.
+	// "syntaxes": ["Python",],
+	"syntaxes": [],
 }

--- a/user-tests/test.py
+++ b/user-tests/test.py
@@ -5,12 +5,12 @@
 # {
 #    "concatenate_adjacent_comments": true,
 #    "concatenate_multiline_comments": false,
-#    "concatenate_over_empty_lines": true,
+#    "concatenate_over_empty_lines": false,
 #    "fold_single_line_comments": false,
 #    "show_first_line": true,
 #    "show_closing_comment_characters": true,
 #    "fold_strings": true,
-#    "ignore_assigned":false,
+#    "ignore_assigned": false
 # }
 
 # For each test the section before the "pass" keyword is what is too be
@@ -27,8 +27,20 @@ def comment_test1():
     pass
     # Comments that are not inline and occur right next to ...
 
+    # Standalone lines are combined if concatenate_over_empty_lines is true.
+
 
 def comment_test2():
+    # Comments that are not inline and occur right next to
+    # each other should be combined into one.
+    #
+    # Not a standalone line
+
+    pass
+    # Comments that are not inline and occur right next to ...
+
+
+def comment_test3():
     """
     A docstring
     """
@@ -39,15 +51,15 @@ def comment_test2():
     # Comment adjacent to docstring
 
 
-def comment_test2():
+def comment_test4():
     """A docstring"""
     # Because these are both singline comments the get combined together.
 
     pass
-    #"""A docstring ...
+    """A docstring""" ...
 
 
-def comment_test3():
+def comment_test5():
     var = []  # inline comment
 
     # Comment referring loop below which shouldn't be combined
@@ -103,6 +115,6 @@ def string_test4():
     )
     pass
     regex = re.compile(
-        r"""...hello\s*...""",
+        r""" ... hello\s* ... """,
         re.VERBOSE | re.IGNORECASE,
     )

--- a/user-tests/test.py
+++ b/user-tests/test.py
@@ -1,0 +1,83 @@
+# pylint: disable-all
+# flake8: noqa
+
+# Settings for matching expected results:
+# {
+#    "concatenate_adjacent_comments": false,
+#    "fold_single_line_comments": false,
+#    "show_first_line": true,
+#    "autofold": true | false,
+#    "fold_strings": true,
+# }
+
+# For each test the section before the "pass" keyword is what is too be
+# folded. What comes after "pass" is a representation of how the folded
+# text is expected to look like.
+
+
+def comment_test1():
+    # Comments that are not inline and occur right next to
+    # each other should be combined into one.
+
+    # Standalone lines should not be combined
+
+    pass
+    # Comments that are not inline and occur right next to ...
+
+    # Standalone lines should not be combined
+
+
+def comment_test2():
+    """
+    A docstring
+    """
+    # Comment adjacent to docstring
+
+    pass
+    """ ... A docstring ... """
+    # Comment adjacent to docstring
+
+
+def comment_test3():
+    var = []  # inline comment
+
+    # Comment referring loop below which shouldn't be combined
+    for i in range(10):
+        var.append(i)
+
+    pass
+    var = []  # inline comment
+
+    # Comment referring loop below which shouldn't be combined
+    for i in range(10):
+        var.append(i)
+
+
+def string_test1():
+    var = (
+        "only triple quoted strings "
+        "should be folded"
+    )
+    pass
+    var = (
+        "only triple quoted strings "
+        "should be folded"
+    )
+
+
+def string_test2():
+    # """
+    # Commented out docstring should be treated as
+    # a multiline comment
+    # """
+    pass
+    # """ ...
+
+
+def string_test3():
+    var = """
+        triple quoted string used in an assignment
+        shouldn't be auto folded
+        """
+    pass
+    var = """ ... triple quoted string used in an assignment ... """

--- a/user-tests/test.py
+++ b/user-tests/test.py
@@ -3,11 +3,14 @@
 
 # Settings for matching expected results:
 # {
-#    "concatenate_adjacent_comments": false,
+#    "concatenate_adjacent_comments": true,
+#    "concatenate_multiline_comments": false,
+#    "concatenate_over_empty_lines": true,
 #    "fold_single_line_comments": false,
 #    "show_first_line": true,
-#    "autofold": true | false,
+#    "show_closing_comment_characters": true,
 #    "fold_strings": true,
+#    "ignore_assigned":false,
 # }
 
 # For each test the section before the "pass" keyword is what is too be
@@ -19,12 +22,10 @@ def comment_test1():
     # Comments that are not inline and occur right next to
     # each other should be combined into one.
 
-    # Standalone lines should not be combined
+    # Standalone lines are combined if concatenate_over_empty_lines is true.
 
     pass
     # Comments that are not inline and occur right next to ...
-
-    # Standalone lines should not be combined
 
 
 def comment_test2():
@@ -36,6 +37,14 @@ def comment_test2():
     pass
     """ ... A docstring ... """
     # Comment adjacent to docstring
+
+
+def comment_test2():
+    """A docstring"""
+    # Because these are both singline comments the get combined together.
+
+    pass
+    #"""A docstring ...
 
 
 def comment_test3():
@@ -55,12 +64,12 @@ def comment_test3():
 
 def string_test1():
     var = (
-        "only triple quoted strings "
+        "only triple quoted multiline strings "
         "should be folded"
     )
     pass
     var = (
-        "only triple quoted strings "
+        "only triple quoted multiline strings "
         "should be folded"
     )
 
@@ -77,7 +86,23 @@ def string_test2():
 def string_test3():
     var = """
         triple quoted string used in an assignment
-        shouldn't be auto folded
+        shouldn't be auto folded when ignore_assigned
+        is true.
         """
     pass
     var = """ ... triple quoted string used in an assignment ... """
+
+
+def string_test4():
+    regex = re.compile(
+        r"""
+        hello\s*
+        world\n
+        """,
+        re.VERBOSE | re.IGNORECASE,
+    )
+    pass
+    regex = re.compile(
+        r"""...hello\s*...""",
+        re.VERBOSE | re.IGNORECASE,
+    )


### PR DESCRIPTION
- Add automatic folding option
  - If `autofold` is `true` than comments will be folded on file load.
  - You can add syntaxes to `syntaxes` if you only want to autofold for some file syntaxes.
- Add fold current comments support
  - Click in a comment and use <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd> to toggle.
- Add show first line option
  - If `show_first_line` is `true` than when you fold a multiline comment it will leave the first line visible.
  - There is also an option to show or not show closing comments characters.
- Add fold strings option
  - If `fold_strings` is `true` than it will also fold strings.
  - There is also an option to ignore assigned strings.
- Added more options to `concatenate_adjacent_comments`
  - Use `concatenate_multiline_comments` to prevent concatenating multiline comments.
  - Use `concatenate_over_empty_lines` to prevent concatenation over blank lines.
